### PR TITLE
fixed vm func order of arguments

### DIFF
--- a/azdata.go
+++ b/azdata.go
@@ -14,7 +14,8 @@ const ApiUrl = "https://prices.azure.com/api/retail/prices"
 const ApiPreview = "2023-01-01-preview"
 
 // sapCur is a slice of strings the represent supported currencies
-var supCur = []string{"USD",
+var supCur = []string{
+	"USD",
 	"AUD",
 	"BRL",
 	"CAD",
@@ -30,7 +31,8 @@ var supCur = []string{"USD",
 	"NZD",
 	"RUB",
 	"SEK",
-	"TWD"}
+	"TWD",
+}
 
 /* list of regions generated with az */
 /* az account list-locations --query "[].{Name:name}" -o table */

--- a/vm.go
+++ b/vm.go
@@ -8,16 +8,16 @@ import (
 
 // GetVmPrice provides the price of a VM in a specific location in a specific
 // currency.
-func (p Pricer) GetVmPrice(location, currency, vmsku string) (VmPrice, error) {
+func (p Pricer) GetVmPrice(vmSku, region, currency string) (VmPrice, error) {
 	// Check currency code
 	if !validateCurrencyCode(currency) {
 		return VmPrice{}, fmt.Errorf("unsupported currency")
 	}
-	if !validateLocation(location) {
+	if !validateLocation(region) {
 		return VmPrice{}, fmt.Errorf("unsupported location")
 	}
 
-	ar, err := p.apg(getVmString(vmsku, location, currency))
+	ar, err := p.apg(getVmString(vmSku, region, currency))
 	if err != nil {
 		slog.Error("Failed to price VM")
 		return VmPrice{}, fmt.Errorf("failed to price vm")
@@ -30,8 +30,8 @@ func (p Pricer) GetVmPrice(location, currency, vmsku string) (VmPrice, error) {
 	}
 
 	vmp := VmPrice{
-		VmSku:    vmsku,
-		Region:   location,
+		VmSku:    vmSku,
+		Region:   region,
 		Currency: currency,
 	}
 
@@ -64,15 +64,15 @@ func (p Pricer) GetVmPrice(location, currency, vmsku string) (VmPrice, error) {
 
 	/* Ensure all fields are populated */
 	if vmp.OneYrRi == 0 {
-		slog.Error("Couldn't retrieve 1 Year RI price", "VmSku", vmsku, "Region", location)
+		slog.Error("Couldn't retrieve 1 Year RI price", "VmSku", vmSku, "Region", region)
 		return VmPrice{}, fmt.Errorf("could not retrieve 1 year RI price for VM")
 	}
 	if vmp.ThreeYrRi == 0 {
-		slog.Error("Couldn't retrieve 3 Year RI price", "VmSku", vmsku, "Region", location)
+		slog.Error("Couldn't retrieve 3 Year RI price", "VmSku", vmSku, "Region", region)
 		return VmPrice{}, fmt.Errorf("could not retrieve 3 year RI price for VM")
 	}
 	if vmp.PaygHrRate == 0 {
-		slog.Error("Couldn't retrieve hourly PAYG price", "VmSku", vmsku, "Region", location)
+		slog.Error("Couldn't retrieve hourly PAYG price", "VmSku", vmSku, "Region", region)
 		return VmPrice{}, fmt.Errorf("could not retrieve hourly PAYG price for VM")
 	}
 

--- a/vm_test.go
+++ b/vm_test.go
@@ -572,9 +572,9 @@ func TestPricer_GetVmPrice(t *testing.T) {
 		apg apiGetter
 	}
 	type args struct {
-		location string
+		vmSku    string
+		region   string
 		currency string
-		vmsku    string
 	}
 	tests := []struct {
 		name    string
@@ -583,22 +583,22 @@ func TestPricer_GetVmPrice(t *testing.T) {
 		want    VmPrice
 		wantErr bool
 	}{
-		{"Good", fields{goodGetter}, args{"uksouth", "GBP", "Standard_D2as_v5"},
+		{"Good", fields{goodGetter}, args{"Standard_D2as_v5", "uksouth", "GBP"},
 			VmPrice{"Standard_D2as_v5", "uksouth", "GBP", 0.077842, 33.53702, 21.601215, 0, 0}, false},
-		{"BadLocation", fields{apiGet}, args{"francewest", "EUR", "Standard_D2ds_v5"}, VmPrice{}, true},
-		{"BadCurrency", fields{apiGet}, args{"uksouth", "ZOP", "Standard_D2ds_v5"}, VmPrice{}, true},
-		{"FailedToPrice", fields{badGetter}, args{"uksouth", "GBP", "Standard_D2ds_v5"}, VmPrice{}, true},
-		{"EmptyResults", fields{emptyGetter}, args{"uksouth", "GBP", "Standard_D2ds_v5"}, VmPrice{}, true},
-		{"No1YrRi", fields{no1yeRiGetter}, args{"uksouth", "GBP", "Standard_D2ds_v5"}, VmPrice{}, true},
-		{"No3YrRi", fields{no3yeRiGetter}, args{"uksouth", "GBP", "Standard_D2ds_v5"}, VmPrice{}, true},
-		{"NoPayg", fields{noPaygRiGetter}, args{"uksouth", "GBP", "Standard_D2ds_v5"}, VmPrice{}, true},
+		{"BadCurrency", fields{apiGet}, args{"Standard_D2ds_v5", "uksouth", "ZOP"}, VmPrice{}, true},
+		{"BadLocation", fields{apiGet}, args{"Standard_D2ds_v5", "francewest", "EUR"}, VmPrice{}, true},
+		{"FailedToPrice", fields{badGetter}, args{"Standard_D2ds_v5", "uksouth", "GBP"}, VmPrice{}, true},
+		{"EmptyResults", fields{emptyGetter}, args{"Standard_D2ds_v5", "uksouth", "GBP"}, VmPrice{}, true},
+		{"No1YrRi", fields{no1yeRiGetter}, args{"Standard_D2ds_v5", "uksouth", "GBP"}, VmPrice{}, true},
+		{"No3YrRi", fields{no3yeRiGetter}, args{"Standard_D2ds_v5", "uksouth", "GBP"}, VmPrice{}, true},
+		{"NoPayg", fields{noPaygRiGetter}, args{"Standard_D2ds_v5", "uksouth", "GBP"}, VmPrice{}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := Pricer{
 				apg: tt.fields.apg,
 			}
-			got, err := p.GetVmPrice(tt.args.location, tt.args.currency, tt.args.vmsku)
+			got, err := p.GetVmPrice(tt.args.vmSku, tt.args.region, tt.args.currency)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Pricer.GetVmPrice() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
This is a breaking change. Users using v.0.0.2 will need to change the order of arguments when calling `GetVmPrice`.

Sorry for the inconvenience, but this is still pre-release. 

There will be no breaking changes when code is production ready.